### PR TITLE
Fixed broken tests and performance bug

### DIFF
--- a/lib/polymorphic_integer_type/extensions.rb
+++ b/lib/polymorphic_integer_type/extensions.rb
@@ -82,20 +82,14 @@ module PolymorphicIntegerType
       }
       base.class_eval {
         def _polymorphic_foreign_types
-          @_polymorphic_foreign_types
+          self.class._polymorphic_foreign_types
         end
 
         def _polymorphic_foreign_types=(types)
-          @_polymorphic_foreign_types = types
+          self.class._polymorphic_foreign_types = types
         end
-
-        self._polymorphic_foreign_types = []
       }
       base.extend(ClassMethods)
-    end
-
-    def _polymorphic_foreign_types
-      self.class._polymorphic_foreign_types
     end
 
     def [](value)

--- a/lib/polymorphic_integer_type/version.rb
+++ b/lib/polymorphic_integer_type/version.rb
@@ -1,3 +1,3 @@
 module PolymorphicIntegerType
-  VERSION = "1.0.6"
+  VERSION = "1.0.7"
 end

--- a/polymorphic_integer_type.gemspec
+++ b/polymorphic_integer_type.gemspec
@@ -23,6 +23,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec"
   spec.add_development_dependency "activerecord", "3.2.11"
   spec.add_development_dependency "mysql", "2.8.1"
-  spec.add_development_dependency "debugger"  
+  spec.add_development_dependency "byebug"
 
 end

--- a/spec/polymorphic_integer_type_spec.rb
+++ b/spec/polymorphic_integer_type_spec.rb
@@ -50,13 +50,14 @@ describe PolymorphicIntegerType do
 
     context "and the link is accessed through the associations" do
       before { link }
-      
+
       it "should have the proper source" do
         expect(source.source_links[0].source).to eql source
       end
     end
-    
+
   end
+
   context "When a link is given polymorphic record" do
     let(:link) { Link.create(:source => source) }
     let(:source) { cat }
@@ -140,7 +141,7 @@ describe PolymorphicIntegerType do
 
 
   end
-  
+
   context "when the association is an STI table" do
     let(:link) { Link.create(:source => source, :target => whiskey) }
     let(:source) { Dog.create(:name => "Bela", :kind => "Dog", :owner => owner) }
@@ -150,6 +151,19 @@ describe PolymorphicIntegerType do
       expect(link.source).to eql source
     end
   end
-  
+
+  describe "#_polymorphic_foreign_types" do
+    subject { Link.new }
+
+    it "is not blank" do
+      expect(subject._polymorphic_foreign_types).to_not be_nil
+      expect(subject._polymorphic_foreign_types).to_not be_empty
+    end
+
+    it "matches the class list" do
+      expect(subject._polymorphic_foreign_types).to eq Link._polymorphic_foreign_types
+    end
+  end
+
 
 end


### PR DESCRIPTION
The instance method `_polymorphic_foreign_types` was being defined twice, and the one that "won" was always returning nil instead of delegating to the class method.

This broke a couple of tests, but also added a performance hit for large result sets (it was always raising / rescuing an exception, which is fairly expensive)